### PR TITLE
Actualizado el año a 2021

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 MugAr
+Copyright (c) 2021 MugAr
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### Descripción
Se actualiza año de la licencia MIT.

### Issues relacionados
1. holamugar/templates#7: Año licencia

